### PR TITLE
setup.py resource specification

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,7 @@ setup(name='mcviz',
       packages=find_packages(),
       entry_points={"console_scripts" : ["mcviz = mcviz:main"]},
       package_data={
-        "mcviz.utils.svg" : ["ParticleData.xml", "texglyph.cache"],
-        "mcviz.utils.svg.data" : ["*.js", "*.xml"],
+        "mcviz.utils.svg.data" : ["*.js", "*.xml","ParticleData.xml", "texglyph.cache"]
       },
       install_requires=[
         'argparse',


### PR DESCRIPTION
Hi,

currently there is a mismatch between mcviz/utils/svg/texglyph.py and setup.py regarding the location of texglyph.cache and ParticleData.xml texglyph.py seems to expect them in mcviz.utils.svg.data while setup.py declares them to be present at mcviz.utils.svg. This causes the cache to be rebuilt everytime (also it needs to be built in the first place because the existing in the data subdir is not found). The diff here fixes setup.py.

Cheers,
Lukas
